### PR TITLE
chore: upgrade go dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/jenkins-x/golang-jenkins v0.0.0-20180919102630-65b83ad42314
 	github.com/jenkins-x/jx-api/v4 v4.0.20
 	github.com/jenkins-x/jx-gitops v0.0.524
-	github.com/jenkins-x/jx-helpers/v3 v3.0.60
+	github.com/jenkins-x/jx-helpers/v3 v3.0.61
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.1
-	github.com/jenkins-x/jx-logging/v3 v3.0.2
+	github.com/jenkins-x/jx-logging/v3 v3.0.3
 	github.com/jenkins-x/lighthouse v0.0.907
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -873,10 +873,14 @@ github.com/jenkins-x/jx-gitops v0.0.524 h1:Wh6tZWL+j9fSu9m5NvpjcdKOf6IZrVC/SbJfC
 github.com/jenkins-x/jx-gitops v0.0.524/go.mod h1:1KgoXM3ywZkL1pHVnWy3IlIksaevibLzWSpj9RR+lzs=
 github.com/jenkins-x/jx-helpers/v3 v3.0.60 h1:w0HgXOAEvCQGaxYD67glMCEDhUG4uQE8jOC/C5f/ai4=
 github.com/jenkins-x/jx-helpers/v3 v3.0.60/go.mod h1:u2ngCSn2vG8bmriBDdOd1y2aQ5DKIft0Gv0mA9WjBmg=
+github.com/jenkins-x/jx-helpers/v3 v3.0.61 h1:WQpQ8tlcn6Dq9SCVjHrzZbfJG/OdWsHLXE4A2l71Hk4=
+github.com/jenkins-x/jx-helpers/v3 v3.0.61/go.mod h1:Q4xn9qdOfYrFEdsCK2dgtzeGGFS7uwW5M55utf4FtYA=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1 h1:zMnxoLRXJJ85PAd9OVPlgXT5T8xHgbmxSMhpYPTF5mw=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.1/go.mod h1:0CYp1ACEgSmOxul1bx5qbZgQGEcyAeGdBOBa+u62zZY=
 github.com/jenkins-x/jx-logging/v3 v3.0.2 h1:9IEeySM86yECc520Spaq38xO8JIpb6QDl1jFBEQHAwg=
 github.com/jenkins-x/jx-logging/v3 v3.0.2/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
+github.com/jenkins-x/jx-logging/v3 v3.0.3 h1:sVACbwiKuaDFYPfJeVAU10MJI4DA6LcH1RqJKwfNozc=
+github.com/jenkins-x/jx-logging/v3 v3.0.3/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 h1:NuRWKUPCEX1wKlXA8ZYSG28qGKd41R7BK11YDQkPwqo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3/go.mod h1:litPp7VZWDRCl8LvXuqGngy+65kkg/+T23TgFnDmfTk=
 github.com/jenkins-x/pipeline v0.0.0-20201002150609-ca0741e5d19a h1:BmT+3ZVyqLrU5iySmp9FED315Mp9sq/yyYSyL2VGZwU=


### PR DESCRIPTION
from: https://github.com/jenkins-x/jx3-versions
