### PR TITLE
fix: detect Jenkins env vars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/jenkins-x/jx-helpers/v3 v3.0.84
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.2
 	github.com/jenkins-x/jx-logging/v3 v3.0.3
-	github.com/jenkins-x/lighthouse-client v0.0.51
+	github.com/jenkins-x/lighthouse-client v0.0.54
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,8 @@ github.com/jenkins-x/jx-logging/v3 v3.0.3 h1:sVACbwiKuaDFYPfJeVAU10MJI4DA6LcH1Rq
 github.com/jenkins-x/jx-logging/v3 v3.0.3/go.mod h1:Vp2ER2SYgGhAgEEHlLwfi2ZB54tz6ya1qExq0A4CKMI=
 github.com/jenkins-x/lighthouse-client v0.0.48 h1:GkjyQct682C6XwsFbYY4lMRHZMuTwY1xxymjfq05P1I=
 github.com/jenkins-x/lighthouse-client v0.0.48/go.mod h1:qyD37zKY0YDXAFjZ6QhdA8gHXMT2rGGP+twZQx/TS2A=
-github.com/jenkins-x/lighthouse-client v0.0.51 h1:kw39aQV3zGt/8qavC5zUfpFPx5wI9YFT3vqdaDX3LKA=
-github.com/jenkins-x/lighthouse-client v0.0.51/go.mod h1:qyD37zKY0YDXAFjZ6QhdA8gHXMT2rGGP+twZQx/TS2A=
+github.com/jenkins-x/lighthouse-client v0.0.54 h1:d3sGMCVQ8CBtYiQLxRAuYup79OF73w2XKnyM+ONwHWA=
+github.com/jenkins-x/lighthouse-client v0.0.54/go.mod h1:qyD37zKY0YDXAFjZ6QhdA8gHXMT2rGGP+twZQx/TS2A=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3 h1:NuRWKUPCEX1wKlXA8ZYSG28qGKd41R7BK11YDQkPwqo=
 github.com/jenkins-x/logrus-stackdriver-formatter v0.2.3/go.mod h1:litPp7VZWDRCl8LvXuqGngy+65kkg/+T23TgFnDmfTk=
 github.com/jenkins-x/pipeline v0.3.2-0.20210118090417-1e821d85abf6 h1:P/UwaE7LPLOZNIsaNkUGW2QU+4HZSgxkrHLa572zL+8=

--- a/pkg/cmd/effective/effective.go
+++ b/pkg/cmd/effective/effective.go
@@ -397,6 +397,9 @@ func (o *Options) addPipelineParameterDefaults(path string, name string, pipelin
 	}
 
 	dscm := &o.DiscoverScm
+	if dscm.Dir == "" {
+		dscm.Dir = filepath.Dir(path)
+	}
 	err := dscm.Validate()
 	if err != nil {
 		return errors.Wrapf(err, "failed to discover repository details")


### PR DESCRIPTION
if being used with the jenkins tekton plugin

also add defaulted labels and use a nicer name so its easier to apply the
resource directly